### PR TITLE
Module upgrade to Terraform 0.12.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,14 +44,6 @@ resource "aws_security_group" "broker-sg" {
     from_port = 0
     to_port   = 0
     protocol  = "-1"
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibility in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
     cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 
@@ -59,14 +51,6 @@ resource "aws_security_group" "broker-sg" {
     from_port = 0
     to_port   = 0
     protocol  = "-1"
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibility in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
     cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 }
@@ -80,14 +64,6 @@ resource "aws_mq_broker" "broker" {
   publicly_accessible = false
   security_groups     = [aws_security_group.broker-sg.id]
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   subnet_ids = slice(
     data.terraform_remote_state.cluster.outputs.internal_subnets_ids,
     0,

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,14 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
 
 data "terraform_remote_state" "cluster" {
   backend = "s3"
 
-  config {
-    bucket = "${var.cluster_state_bucket}"
+  config = {
+    bucket = var.cluster_state_bucket
     region = "eu-west-1"
     key    = "cloud-platform/${var.cluster_name}/terraform.tfstate"
   }
@@ -18,8 +21,8 @@ resource "random_id" "id" {
 locals {
   identifier        = "cloud-platform-${random_id.id.hex}"
   mq_admin_user     = "cp${random_string.username.result}"
-  mq_admin_password = "${random_string.password.result}"
-  subnets           = "${var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ" ? 2 : 1 }"
+  mq_admin_password = random_string.password.result
+  subnets           = var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ" ? 2 : 1
 }
 
 resource "random_string" "username" {
@@ -33,42 +36,70 @@ resource "random_string" "password" {
 }
 
 resource "aws_security_group" "broker-sg" {
-  name        = "${local.identifier}"
+  name        = local.identifier
   description = "Allow all inbound traffic"
-  vpc_id      = "${data.terraform_remote_state.cluster.vpc_id}"
+  vpc_id      = data.terraform_remote_state.cluster.outputs.vpc_id
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["${data.terraform_remote_state.cluster.internal_subnets}"]
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibility in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["${data.terraform_remote_state.cluster.internal_subnets}"]
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibility in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 }
 
 resource "aws_mq_broker" "broker" {
-  broker_name         = "${local.identifier}"
-  engine_type         = "${var.engine_type}"
-  engine_version      = "${var.engine_version}"
-  deployment_mode     = "${var.deployment_mode}"
-  host_instance_type  = "${var.host_instance_type}"
+  broker_name         = local.identifier
+  engine_type         = var.engine_type
+  engine_version      = var.engine_version
+  deployment_mode     = var.deployment_mode
+  host_instance_type  = var.host_instance_type
   publicly_accessible = false
-  security_groups     = ["${aws_security_group.broker-sg.id}"]
+  security_groups     = [aws_security_group.broker-sg.id]
 
-  subnet_ids = ["${slice(data.terraform_remote_state.cluster.internal_subnets_ids, 0, local.subnets)}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  subnet_ids = slice(
+    data.terraform_remote_state.cluster.outputs.internal_subnets_ids,
+    0,
+    local.subnets,
+  )
 
-  user = [{
-    username       = "${local.mq_admin_user}"
-    password       = "${local.mq_admin_password}"
+  user {
+    username       = local.mq_admin_user
+    password       = local.mq_admin_password
     groups         = ["admin"]
     console_access = false
-  }]
+  }
 
   auto_minor_version_upgrade = false
 
@@ -83,12 +114,13 @@ resource "aws_mq_broker" "broker" {
     time_zone   = "UTC"
   }
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,20 @@
 output "primary_amqp_ssl_endpoint" {
-  value       = "${aws_mq_broker.broker.instances.0.endpoints.1}"
+  value       = aws_mq_broker.broker.instances[0].endpoints[1]
   description = "AmazonMQ primary AMQP+SSL endpoint"
 }
 
 output "primary_stomp_ssl_endpoint" {
-  value       = "${aws_mq_broker.broker.instances.0.endpoints.2}"
+  value       = aws_mq_broker.broker.instances[0].endpoints[2]
   description = "AmazonMQ primary STOMP+SSL endpoint"
 }
 
 output "username" {
-  value       = "${local.mq_admin_user}"
+  value       = local.mq_admin_user
   description = "broker username"
 }
 
 output "password" {
-  value       = "${local.mq_admin_password}"
+  value       = local.mq_admin_password
   description = "broker password"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,14 @@ variable "cluster_state_bucket" {
   default     = "cloud-platform-terraform-state"
 }
 
-variable "team_name" {}
+variable "team_name" {
+}
 
-variable "application" {}
+variable "application" {
+}
 
-variable "environment-name" {}
+variable "environment-name" {
+}
 
 variable "is-production" {
   default = "false"
@@ -51,3 +54,4 @@ variable "aws_region" {
   description = "Region into which the resource will be created."
   default     = "eu-west-2"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
To upgrade the module do:
when in terraform0.11.14 version, do terraform 0.12checklist. See if everything looks fine
switch to terraform 0.12.13 using tfswitch
do terraform 0.12upgrade

Fixed list interpolations manually

example/*.tf wasnot upgraded and will be done when needed.