### PR TITLE
Add "namespace" tag to AMQ resource

### DIFF
--- a/example/amq.tf
+++ b/example/amq.tf
@@ -13,6 +13,7 @@ module "example_team_broker" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "example-team@digital.justice.gov.uk"
+  namespace              = var.namespace
 
   providers = {
     # Can be either 'aws.london' or 'aws.ireland'

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ resource "aws_mq_broker" "broker" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,9 @@ variable "business-unit" {
   default     = "mojdigital"
 }
 
+variable "namespace" {
+}
+
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }


### PR DESCRIPTION
Why:
Tag all AWS resources with namespace name#2348